### PR TITLE
Use Ollama with LlamaIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains a minimal example for building a Retrieval-Augmented Generation (RAG) workflow with [LlamaIndex](https://github.com/run-llama/llama_index).
 
-The `starter.py` script follows the official [starter example](https://docs.llamaindex.ai/en/stable/getting_started/starter_example_local/) from the docs. It loads text files from the `data/` directory, creates an index and runs a sample query using your OpenAI API key.
+The `starter.py` script follows the official [starter example](https://docs.llamaindex.ai/en/stable/getting_started/starter_example_local/) from the docs. It loads text files from the `data/` directory, creates an index and runs a sample query using a model served by [Ollama](https://ollama.com/).
 
 ## Setup
 
@@ -12,11 +12,16 @@ The `starter.py` script follows the official [starter example](https://docs.llam
 pip install -r requirements.txt
 ```
 
-2. Set your OpenAI API key and run the script
+2. Ensure [Ollama](https://ollama.com/) is installed and running locally.
+   If needed, pull a model and start the server:
 
 ```bash
-export OPENAI_API_KEY=sk-...
-python starter.py
+ollama pull llama2
+ollama serve
 ```
 
-Replace `sk-...` with your actual API key.
+3. Run the script
+
+```bash
+python starter.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 llama-index
-openai
+llama-index-llms-ollama
+ollama

--- a/src/starter.py
+++ b/src/starter.py
@@ -1,8 +1,8 @@
-import os
-from llama_index.core import VectorStoreIndex, SimpleDirectoryReader
+from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, Settings
+from llama_index.llms.ollama import Ollama
 
-# Set your OpenAI API key
-os.environ.setdefault('OPENAI_API_KEY', 'sk-...')  # TODO: replace with your key
+# Configure Ollama as the LLM backend
+Settings.llm = Ollama(model="llama2")
 
 # Load documents from the data directory
 reader = SimpleDirectoryReader('data')


### PR DESCRIPTION
## Summary
- switch example code to use Ollama instead of OpenAI
- document Ollama usage in the README
- update requirements

## Testing
- `python -m py_compile src/starter.py`

------
https://chatgpt.com/codex/tasks/task_e_6861830f503c83209eb6eeadb4d4fbd0