### PR TITLE
Add basic index analytics helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ This repository contains a minimal example for building a Retrieval-Augmented Ge
 
 The `starter.py` script follows the official [starter example](https://docs.llamaindex.ai/en/stable/getting_started/starter_example_local/) from the docs. It loads text files from the `data/` directory, creates an index and runs a sample query using a model served by [Ollama](https://ollama.com/).
 
+The script now also prints statistics about how the index was created. This
+information helps understand how documents were chunked and stored.
+
 ## Setup
 
 1. Install dependencies

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -1,0 +1,30 @@
+from typing import List, Dict
+from llama_index.core import VectorStoreIndex
+
+
+def chunk_statistics(index: VectorStoreIndex) -> List[Dict[str, int]]:
+    """Return basic statistics about each chunk in the index."""
+    docstore = index.storage_context.docstore
+    results = []
+    for node in docstore.docs.values():
+        try:
+            text = node.get_content()
+        except Exception:
+            text = str(node)
+        results.append({
+            "node_id": node.node_id,
+            "source": getattr(node, "ref_doc_id", "unknown"),
+            "characters": len(text),
+            "words": len(text.split()),
+        })
+    return results
+
+
+def print_chunk_statistics(index: VectorStoreIndex) -> None:
+    """Pretty print chunk statistics for the given index."""
+    stats = chunk_statistics(index)
+    print(f"Index contains {len(stats)} chunks")
+    for item in stats:
+        print(
+            f"Chunk {item['node_id']} from {item['source']}: {item['words']} words, {item['characters']} characters"
+        )

--- a/src/starter.py
+++ b/src/starter.py
@@ -2,6 +2,7 @@ from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, Settings
 from llama_index.core.agent.workflow import AgentWorkflow
 from llama_index.llms.ollama import Ollama
 from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from .analytics import print_chunk_statistics
 import asyncio
 import os
 
@@ -21,6 +22,8 @@ index = VectorStoreIndex.from_documents(
     # we can optionally override the embed_model here
     # embed_model=Settings.embed_model,
 )
+
+print_chunk_statistics(index)
 query_engine = index.as_query_engine(
     # we can optionally override the llm here
     # llm=Settings.llm,


### PR DESCRIPTION
## Summary
- add `print_chunk_statistics` helper to inspect index chunks
- call the helper in `starter.py`
- document analytics capability in `README`

## Testing
- `python src/starter.py` *(fails: ModuleNotFoundError: No module named 'llama_index')*

------
https://chatgpt.com/codex/tasks/task_e_6862a04b3cc08320b05d34a8bcc40e28