### PR TITLE
Add chunk snippet to statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This repository contains a minimal example for building a Retrieval-Augmented Ge
 
 The `starter.py` script follows the official [starter example](https://docs.llamaindex.ai/en/stable/getting_started/starter_example_local/) from the docs. It loads text files from the `data/` directory, creates an index and runs a sample query using a model served by [Ollama](https://ollama.com/).
 
-The script now also prints statistics about how the index was created. This
-information helps understand how documents were chunked and stored.
+The script now also prints statistics about how the index was created. Each
+chunk's statistics include a short snippet from the original text so you can see
+what content ended up in the index.
 
 ## Setup
 

--- a/src/analytics.py
+++ b/src/analytics.py
@@ -11,11 +11,13 @@ def chunk_statistics(index: VectorStoreIndex) -> List[Dict[str, int]]:
             text = node.get_content()
         except Exception:
             text = str(node)
+        snippet = " ".join(text.split())[:60]
         results.append({
             "node_id": node.node_id,
             "source": getattr(node, "ref_doc_id", "unknown"),
             "characters": len(text),
             "words": len(text.split()),
+            "snippet": snippet,
         })
     return results
 
@@ -26,5 +28,5 @@ def print_chunk_statistics(index: VectorStoreIndex) -> None:
     print(f"Index contains {len(stats)} chunks")
     for item in stats:
         print(
-            f"Chunk {item['node_id']} from {item['source']}: {item['words']} words, {item['characters']} characters"
+            f"Chunk {item['node_id']} from {item['source']}: {item['words']} words, {item['characters']} characters | {item['snippet']}"
         )


### PR DESCRIPTION
## Summary
- extend chunk statistics with a text snippet for each chunk
- show that snippet when printing statistics
- document this additional info in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862a66e306883209fa1f40cdca35ffc