### PR TITLE
Add AIM Basic downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,9 @@ ollama pull llama3
 ```bash
 python starter.py
 ```
+
+4. Download the AIM Basic PDF
+
+```bash
+python src/download_aim.py
+```

--- a/src/download_aim.py
+++ b/src/download_aim.py
@@ -1,0 +1,26 @@
+import os
+import urllib.request
+import argparse
+
+AIM_URL = "https://www.faa.gov/air_traffic/publications/atpubs/aim_basic/aim.pdf"
+
+
+def download_aim(output_path: str) -> None:
+    """Download the AIM Basic PDF to the given path."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    print(f"Downloading {AIM_URL} to {output_path}...")
+    urllib.request.urlretrieve(AIM_URL, output_path)
+    print("Download complete")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Download the Aeronautical Information Manual (AIM) Basic PDF"
+    )
+    parser.add_argument(
+        "--output",
+        default="data/aim_basic.pdf",
+        help="Destination file path",
+    )
+    args = parser.parse_args()
+    download_aim(args.output)


### PR DESCRIPTION
## Summary
- add script to download the FAA AIM Basic PDF
- document the downloader in README

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6862ac13f3408320bb2ed27309fdce36