### PR TITLE
Add SAFO downloader script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ python starter.py
 ```bash
 python src/download_aim.py
 ```
+
+5. Download SAFO PDFs
+
+```bash
+python src/download_safo.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ llama-index
 llama-index-llms-ollama
 llama-index-embeddings-huggingface
 ollama
+beautifulsoup4
+requests
+tqdm

--- a/src/download_safo.py
+++ b/src/download_safo.py
@@ -1,0 +1,47 @@
+import re
+import time
+from pathlib import Path
+import argparse
+
+import requests
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+
+BASE = "https://www.faa.gov"
+LIST_URL = f"{BASE}/other_visit/aviation_industry/airline_operators/airline_safety/safo/all_safos"
+
+
+def download_safo(output_dir: str) -> None:
+    """Download all SAFO PDFs to the given directory."""
+    out = Path(output_dir).resolve()
+    out.mkdir(parents=True, exist_ok=True)
+
+    response = requests.get(LIST_URL, timeout=30)
+    soup = BeautifulSoup(response.text, "html.parser")
+    pdf_links = {
+        BASE + a["href"]
+        for a in soup.find_all("a", href=re.compile(r"\.pdf$", re.I))
+    }
+
+    for url in tqdm(sorted(pdf_links), desc="Downloading SAFOs"):
+        fname = out / url.split("/")[-1]
+        if fname.exists():
+            continue
+        r = requests.get(url, timeout=60)
+        fname.write_bytes(r.content)
+        time.sleep(0.2)
+
+    print(f"Saved {len(list(out.glob('*.pdf')))} SAFO PDFs \u2192 {out}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Download Safety Alerts for Operators (SAFO) PDFs"
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="data/safo",
+        help="Destination directory",
+    )
+    args = parser.parse_args()
+    download_safo(args.output_dir)


### PR DESCRIPTION
## Summary
- add script to download FAA SAFO PDFs
- document the new script in README
- include dependencies for the script in requirements

## Testing
- `python -m py_compile src/download_safo.py`
- `python src/download_safo.py --help`
- `python src/download_safo.py --output-dir tmp/safo_download_test` *(fails: Unable to connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6862af3092448320a4f87ca5b9715e68