### PR TITLE
Add SmartPDFLoader for PDF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ python src/download_aim.py
 ```bash
 python src/download_safo.py
 ```
+
+6. Parse PDFs using the smart loader
+
+```bash
+python -c "from src import load_pdfs; print(len(load_pdfs(['data/aim_basic.pdf'])))"
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ ollama
 beautifulsoup4
 requests
 tqdm
+llama-index-readers-smart-pdf-loader

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+from .pdf_loader import load_pdfs

--- a/src/pdf_loader.py
+++ b/src/pdf_loader.py
@@ -1,0 +1,12 @@
+from typing import Sequence, List
+from llama_index.core.schema import Document
+from llama_index.readers.smart_pdf_loader import SmartPDFLoader
+
+
+def load_pdfs(paths: Sequence[str]) -> List[Document]:
+    """Load one or more PDFs using SmartPDFLoader."""
+    loader = SmartPDFLoader()
+    documents: List[Document] = []
+    for path in paths:
+        documents.extend(loader.load_data(str(path)))
+    return documents


### PR DESCRIPTION
## Summary
- add a small utility wrapper for the `SmartPDFLoader` reader
- expose `load_pdfs` from `src` package
- document how to use the loader in the README
- include `llama-index-readers-smart-pdf-loader` in dependencies

## Testing
- `python -m py_compile src/pdf_loader.py src/__init__.py src/starter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862b16a39b88320ac3bf361ce50bedd