### PR TITLE
Add persistent index utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This repository contains a minimal example for building a Retrieval-Augmented Generation (RAG) workflow with [LlamaIndex](https://github.com/run-llama/llama_index).
 
-The `starter.py` script follows the official [starter example](https://docs.llamaindex.ai/en/stable/getting_started/starter_example_local/) from the docs. It loads text files from the `data/` directory, creates an index and runs a sample query using a model served by [Ollama](https://ollama.com/).
+The `starter.py` script follows the official [starter example](https://docs.llamaindex.ai/en/stable/getting_started/starter_example_local/) from the docs. It now loads a persisted index if one exists so you don't have to rebuild it every time. Use `build_index.py` to create the index in advance.
 
-The script now also prints statistics about how the index was created. Each
+Both scripts print statistics about how the index was created. Each
 chunk's statistics include a short snippet from the original text so you can see
 what content ended up in the index.
 
@@ -23,25 +23,31 @@ pip install -r requirements.txt
 ollama pull llama3
 ```
 
-3. Run the script (set `TOP_K` to change how many chunks to search)
+3. Build the index (only needed once)
 
 ```bash
-TOP_K=8 python starter.py
+python src/build_index.py
 ```
 
-4. Download the AIM Basic PDF
+4. Run the query script (set `TOP_K` to change how many chunks to search)
+
+```bash
+TOP_K=8 python src/starter.py
+```
+
+5. Download the AIM Basic PDF
 
 ```bash
 python src/download_aim.py
 ```
 
-5. Download SAFO PDFs
+6. Download SAFO PDFs
 
 ```bash
 python src/download_safo.py
 ```
 
-6. Parse PDFs using the smart loader
+7. Parse PDFs using the smart loader
 
 ```bash
 python -c "from src import load_pdfs; print(len(load_pdfs(['data/aim_basic.pdf'])))"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,2 @@
 from .pdf_loader import load_pdfs
+from .index_utils import build_index, load_index, load_or_create_index

--- a/src/build_index.py
+++ b/src/build_index.py
@@ -1,0 +1,25 @@
+"""Utility script to build and persist the document index."""
+
+import argparse
+
+from .analytics import print_chunk_statistics
+from .index_utils import build_index, DEFAULT_DATA_DIR, DEFAULT_PERSIST_DIR
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create and persist the index")
+    parser.add_argument(
+        "--data-dir",
+        default=DEFAULT_DATA_DIR,
+        help="Directory containing source documents",
+    )
+    parser.add_argument(
+        "--persist-dir",
+        default=DEFAULT_PERSIST_DIR,
+        help="Where to store the index",
+    )
+    args = parser.parse_args()
+
+    index = build_index(args.data_dir, args.persist_dir)
+    print("Index built and saved to", args.persist_dir)
+    print_chunk_statistics(index)

--- a/src/index_utils.py
+++ b/src/index_utils.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, StorageContext, load_index_from_storage
+from llama_index.core import Settings
+from llama_index.llms.ollama import Ollama
+from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+
+
+DEFAULT_DATA_DIR = "data"
+DEFAULT_PERSIST_DIR = "index_storage"
+
+
+# Configure global defaults so imported scripts don't need to
+Settings.embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-base-en-v1.5")
+Settings.llm = Ollama(
+    model="llama3.1",
+    request_timeout=360.0,
+    context_window=8000,
+)
+
+
+def build_index(data_dir: str = DEFAULT_DATA_DIR, persist_dir: str = DEFAULT_PERSIST_DIR) -> VectorStoreIndex:
+    """Create a new index from documents in ``data_dir`` and persist it."""
+    documents = SimpleDirectoryReader(data_dir).load_data()
+    index = VectorStoreIndex.from_documents(documents)
+    index.storage_context.persist(persist_dir)
+    return index
+
+
+def load_index(persist_dir: str = DEFAULT_PERSIST_DIR) -> VectorStoreIndex:
+    """Load an existing index from ``persist_dir``."""
+    storage_context = StorageContext.from_defaults(persist_dir=persist_dir)
+    return load_index_from_storage(storage_context)
+
+
+def load_or_create_index(data_dir: str = DEFAULT_DATA_DIR, persist_dir: str = DEFAULT_PERSIST_DIR) -> VectorStoreIndex:
+    """Load an index if it exists, otherwise create a new one."""
+    if Path(persist_dir).exists():
+        return load_index(persist_dir)
+    return build_index(data_dir, persist_dir)

--- a/src/starter.py
+++ b/src/starter.py
@@ -1,27 +1,20 @@
-from llama_index.core import VectorStoreIndex, SimpleDirectoryReader, Settings
-from llama_index.core.agent.workflow import AgentWorkflow
-from llama_index.llms.ollama import Ollama
-from llama_index.embeddings.huggingface import HuggingFaceEmbedding
-from .analytics import print_chunk_statistics
+"""Example script for querying a persisted index."""
+
 import asyncio
 import os
 
-# Settings control global defaults
-Settings.embed_model = HuggingFaceEmbedding(model_name="BAAI/bge-base-en-v1.5")
-Settings.llm = Ollama(
-    model="llama3.1",
-    request_timeout=360.0,
-    # Manually set the context window to limit memory usage
-    context_window=8000,
+from llama_index.core.agent.workflow import AgentWorkflow
+from llama_index.core import Settings
+from .analytics import print_chunk_statistics
+from .index_utils import (
+    DEFAULT_DATA_DIR,
+    DEFAULT_PERSIST_DIR,
+    load_or_create_index,
 )
 
-# Create a RAG tool using LlamaIndex
-documents = SimpleDirectoryReader("data").load_data()
-index = VectorStoreIndex.from_documents(
-    documents,
-    # we can optionally override the embed_model here
-    # embed_model=Settings.embed_model,
-)
+
+# Load an existing index or build it if needed
+index = load_or_create_index(DEFAULT_DATA_DIR, DEFAULT_PERSIST_DIR)
 
 print_chunk_statistics(index)
 
@@ -30,8 +23,6 @@ print_chunk_statistics(index)
 top_k = int(os.getenv("TOP_K", "8"))
 
 query_engine = index.as_query_engine(
-    # we can optionally override the llm here
-    # llm=Settings.llm,
     similarity_top_k=top_k,
     similarity_cutoff=0.75,
 )


### PR DESCRIPTION
## Summary
- add helper to build, load or re-use an index
- expose index utils from package
- refactor `starter.py` to reuse a saved index
- add `build_index.py` utility and update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6877fb000a70832088d03a3abe566874